### PR TITLE
Update exports.jl

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -678,6 +678,7 @@ export
     ifelse,
     objectid,
     sizeof,
+    summarysize,
 
 # tasks and conditions
     Condition,


### PR DESCRIPTION
`Base.summarysize` is more informative than `sizeof` and is the one used by `varinfo`